### PR TITLE
[Fixed] Mistyped dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 install_requires = [
-    'minion.plugin_service',
+    'minion-backend',
 ]
 
 setup(name="minion.zest_plugin",
@@ -15,6 +15,6 @@ setup(name="minion.zest_plugin",
       author="Mozilla",
       author_email="minion@mozilla.com",
       packages=['minion', 'minion.plugins'],
-      namespace_packages=['minion.plugins'],
+      namespace_packages=['minion','minion.plugins'],
       include_package_data=True,
       install_requires = install_requires)


### PR DESCRIPTION
Fixed an possible mistyped dependency issue that was causing unsuccessful installation of this plugin on Ubuntu 12.04 x86 (under virtualevn in develop mode). Please see if this PR can be accepted.
